### PR TITLE
解决与Steam Bundle Sites Extension的冲突

### DIFF
--- a/HKR.user.js
+++ b/HKR.user.js
@@ -310,7 +310,7 @@
                     let node = nodes.item(i);
                     let headingNode = node.getElementsByClassName('heading-text');
                     if (headingNode.length == 1) {
-                        let headingText = headingNode.item(0).firstElementChild.innerText;
+                        let headingText = headingNode.item(0).firstElementChild.innerText.trim();
                         if (productsInfo[headingText]) {
                             // Add Machine Name
                             let machineNameElem = document.createElement('span');


### PR DESCRIPTION
Steam Bundle Sites Extension会在每个游戏名后面加上一个空格。
这样会使productsInfo[headingText]永远都为undefined。
最好trim一下headingText里面的文本 ^^